### PR TITLE
Adding CSS custom properties dynamic styling example and more

### DIFF
--- a/hello-world-project/cms-assets/components/islands/TodoList.jsx
+++ b/hello-world-project/cms-assets/components/islands/TodoList.jsx
@@ -39,7 +39,7 @@ function TodoItem({ todo, onRemove, onUpdate }) {
           todo.completed ? styles.complete : styles.notComplete
         }`}
       >
-        <input type="checkbox" checked={todo.completed} onChange={() => {}} />
+        <input type="checkbox" defaultChecked={todo.completed} />
         {todo.text}
         {todo.dateAdded ? (
           <span className={styles.todoDateAdded}>{todo.dateAdded}</span>
@@ -47,9 +47,9 @@ function TodoItem({ todo, onRemove, onUpdate }) {
           ''
         )}
       </div>
-      <div className={styles.todoRemove} onClick={handleTodoRemoveClick}>
-        -
-      </div>
+      <button className={styles.todoRemove} onClick={handleTodoRemoveClick}>
+        ×
+      </button>
     </li>
   );
 }

--- a/hello-world-project/cms-assets/components/islands/TodoList.jsx
+++ b/hello-world-project/cms-assets/components/islands/TodoList.jsx
@@ -3,6 +3,13 @@ import { useState } from 'react';
 import Button from './Button.jsx';
 import styles from '../../styles/todo.module.css';
 
+// This TodoList component highlights a few different things:
+//  - A component to be used as an Island for client-side interactivity
+//  - Picking up a default or initial value that is server rendered, but in the
+//    browser is merely the initial state value that is changed by interaction
+//  - Examples of various ways to do conditional styling based on incoming props
+//    or module fields (inline comments below)
+
 let id = 0;
 const todoSortByCompleted = (todoA, todoB) => {
   if (todoA.completed && todoB.completed) {
@@ -36,6 +43,8 @@ function TodoItem({ todo, onRemove, onUpdate }) {
       <div
         onClick={handleTodoCompleteClick}
         className={`${styles.todo} ${
+          // Example of using a className to dynamically toggle a dynamic style
+          // (via state, prop, or module field value)
           todo.completed ? styles.complete : styles.notComplete
         }`}
       >
@@ -54,7 +63,7 @@ function TodoItem({ todo, onRemove, onUpdate }) {
   );
 }
 
-function TodoList({ initialTodos = [], buttonColor }) {
+function TodoList({ initialTodos = [], buttonColor, completeTodoOpacity }) {
   const [todoList, setTodoList] = useState(() =>
     initialTodosMapped(initialTodos),
   );
@@ -95,8 +104,16 @@ function TodoList({ initialTodos = [], buttonColor }) {
     }
   };
 
+  // Example of setting a CSS custom property value that is picked up by other CSS
+  // This is a great way to keep more styling logic inside your CSS file and "pass"
+  // a dynamic property or module field value into that CSS file (see
+  // --todo-complete-opacity referenced in todo.module.css)
+  const customCssProperties = {
+    '--todo-complete-opacity': completeTodoOpacity / 100,
+  };
+
   return (
-    <div className={styles.todoListContainer}>
+    <div className={styles.todoListContainer} style={customCssProperties}>
       <div className={styles.toDoForm}>
         <input
           className={styles.todoInput}
@@ -107,9 +124,9 @@ function TodoList({ initialTodos = [], buttonColor }) {
         />
 
         <Button
-          style={{
-            backgroundColor: buttonColor.color,
-          }}
+          // Example of using inline style attribute (with React's style syntax)
+          // to directly set a dynamic style on an element
+          style={{ backgroundColor: buttonColor.color }}
           onClick={handleAddTodoClick}
           disabled={!todoInput}
         >

--- a/hello-world-project/cms-assets/components/modules/TodoList/fields.jsx
+++ b/hello-world-project/cms-assets/components/modules/TodoList/fields.jsx
@@ -5,6 +5,7 @@ import {
   BooleanField,
   TextField,
   ColorField,
+  NumberField,
 } from '@hubspot/cms-components/fields';
 
 /**
@@ -13,7 +14,7 @@ import {
  */
 export const fields = (
   <ModuleFields>
-    <FieldGroup name="default_todo" label="Default Todo">
+    <FieldGroup name="default_todo" label="Default Todo" expanded={false}>
       <TextField
         label="Todo title"
         name="text"
@@ -22,6 +23,19 @@ export const fields = (
       />
       <BooleanField label="Todo Completed" name="completed" default={false} />
     </FieldGroup>
-    <ColorField name="button_color" default={{ color: '#F7761F' }} />
+    <ColorField
+      label="Button color"
+      name="button_color"
+      default={{ color: '#F7761F' }}
+    />
+    <NumberField
+      label="Complete todo opacity"
+      name="complete_todo_opacity"
+      displayWidth="half_width"
+      default={50}
+      min={0}
+      max={100}
+      suffix="%"
+    />
   </ModuleFields>
 );

--- a/hello-world-project/cms-assets/components/modules/TodoList/index.jsx
+++ b/hello-world-project/cms-assets/components/modules/TodoList/index.jsx
@@ -18,7 +18,11 @@ import Layout from '../../Layout.jsx';
  * Note: only props that can be serialized are supported
  */
 export const Component = (props) => {
-  const { default_todo: defaultTodos, button_color: buttonColor } = props;
+  const {
+    default_todo: defaultTodos,
+    button_color: buttonColor,
+    complete_todo_opacity: completeTodoOpacity,
+  } = props;
   return (
     <Layout>
       <Island
@@ -28,6 +32,7 @@ export const Component = (props) => {
         // TodoList props:
         initialTodos={[defaultTodos]}
         buttonColor={buttonColor}
+        completeTodoOpacity={completeTodoOpacity}
       />
     </Layout>
   );

--- a/hello-world-project/cms-assets/styles/todo.module.css
+++ b/hello-world-project/cms-assets/styles/todo.module.css
@@ -102,10 +102,10 @@
 .todoRemove {
   /* Remove default button element styles */
   background: none;
-	border: none;
-	padding: 0;
-	font: inherit;
-	cursor: pointer;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
 
   transition: 0.1s opacity linear, 0.1s color linear;
   font-size: 2em;

--- a/hello-world-project/cms-assets/styles/todo.module.css
+++ b/hello-world-project/cms-assets/styles/todo.module.css
@@ -119,7 +119,7 @@
 }
 
 .todo.complete {
-  opacity: 50%;
+  opacity: var(--todo-complete-opacity);
   background-color: #dbe4ed;
   border-color: #b6c7d6;
 }

--- a/hello-world-project/cms-assets/styles/todo.module.css
+++ b/hello-world-project/cms-assets/styles/todo.module.css
@@ -93,11 +93,20 @@
   color: gray;
 }
 
-.todoContainer:hover > .todoRemove {
+.todoContainer:hover > .todoRemove,
+.todoRemove:focus
+{
   opacity: 100%;
 }
 
 .todoRemove {
+  /* Remove default button element styles */
+  background: none;
+	border: none;
+	padding: 0;
+	font: inherit;
+	cursor: pointer;
+
   transition: 0.1s opacity linear, 0.1s color linear;
   font-size: 2em;
   color: grey;


### PR DESCRIPTION
Changes:
  - Adding an example of dynamically styling a module field value via CSS custom properties (and some comments on various dynamic styling approaches)
  - Improve keyboard accessibility of delete button, using a `<button>` and making tabbing to the delete button make it visible
  - Remove React checkbox input warning without needing an empty onChange func
