### PR TITLE
combine CMS dependencies into one package level

### DIFF
--- a/hello-world-project/cms-assets/package.json
+++ b/hello-world-project/cms-assets/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "dependencies": {
+    "@hubspot/cms-dev-server": "latest",
     "@hubspot/cms-components": "latest",
     "prop-types": "^15.8.1",
     "react": "^18.1.0"

--- a/hello-world-project/cms-assets/package.json
+++ b/hello-world-project/cms-assets/package.json
@@ -15,6 +15,7 @@
     "vitest": "^0.24.3"
   },
   "scripts": {
+    "start": "hs-cms-dev-server .",
     "test": "vitest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,19 +4,16 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@hubspot/cli": "^4.0.1",
-    "@hubspot/cms-dev-server": "latest",
     "@hubspot/prettier-plugin-hubl": "latest",
     "eslint": "^8.24.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-react": "^7.31.10",
-    "prettier": "^2.7.1",
-    "yarpm": "^1.2.0"
+    "prettier": "^2.7.1"
   },
   "scripts": {
-    "start": "hs-cms-dev-server hello-world-project/cms-assets",
+    "start": "yarn --cwd hello-world-project/cms-assets hs-cms-dev-server .",
     "lint:js": "eslint . --ext .js,.jsx",
     "prettier": "prettier . --check",
-    "postinstall": "cd hello-world-project && cd cms-assets && yarpm install",
     "watch:hubl": "hs watch hello-world-theme hello-world-theme",
     "upload:hubl": "hs upload hello-world-theme hello-world-theme",
     "deploy": "hs project upload hello-world-project",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "yarpm": "^1.2.0"
   },
   "scripts": {
-    "start": "yarn --cwd hello-world-project/cms-assets start",
+    "start": "cd hello-world-project/cms-assets && yarpm start",
     "postinstall": "cd hello-world-project/cms-assets && yarpm install",
     "lint:js": "eslint . --ext .js,.jsx",
     "prettier": "prettier . --check",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "eslint": "^8.24.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-react": "^7.31.10",
-    "prettier": "^2.7.1"
+    "prettier": "^2.7.1",
+    "yarpm": "^1.2.0"
   },
   "scripts": {
     "start": "yarn --cwd hello-world-project/cms-assets start",
+    "postinstall": "cd hello-world-project/cms-assets && yarpm install",
     "lint:js": "eslint . --ext .js,.jsx",
     "prettier": "prettier . --check",
     "watch:hubl": "hs watch hello-world-theme hello-world-theme",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prettier": "^2.7.1"
   },
   "scripts": {
-    "start": "yarn --cwd hello-world-project/cms-assets hs-cms-dev-server .",
+    "start": "yarn --cwd hello-world-project/cms-assets start",
     "lint:js": "eslint . --ext .js,.jsx",
     "prettier": "prettier . --check",
     "watch:hubl": "hs watch hello-world-theme hello-world-theme",


### PR DESCRIPTION
moves `@hubspot/cms-dev-server` to be a dependency at the subcomponent level to improve support for eventually resolving third-party dependencies